### PR TITLE
Fix typo in feed note.

### DIFF
--- a/config/filters/index.js
+++ b/config/filters/index.js
@@ -144,7 +144,7 @@ export default {
       const date = new Date(entry[dateKey])
       let excerpt = ''
       let url = ''
-      const feedNote = '<hr/><p>This is a full text feed, but not all content can be rendered perfeclty within the feed. If something looks off, feel free to <a href="https://coryd.dev">visit my site</a> for the original post.</p>'
+      const feedNote = '<hr/><p>This is a full text feed, but not all content can be rendered perfectly within the feed. If something looks off, feel free to <a href="https://coryd.dev">visit my site</a> for the original post.</p>'
 
       // set the entry url
       if (entry.url.includes('http')) url = entry.url


### PR DESCRIPTION
"perfeclty" => "perfectly"